### PR TITLE
Support arrow keys in linux

### DIFF
--- a/platform/linux.js
+++ b/platform/linux.js
@@ -56,7 +56,11 @@ const spkeys = {
   'f19': 'F19',
   'f20': 'F20',
   'bs': 'BackSpace',
-  'backspace': 'BackSpace'
+  'backspace': 'BackSpace',
+  'up': 'Up',
+  'right': 'Right',
+  'down': 'Down',
+  'left': 'Left'
 }
 
 function send(key, metaKeys) {

--- a/test/simple.js
+++ b/test/simple.js
@@ -30,4 +30,5 @@ if (process.platform == 'win32') {
 if (process.platform == 'linux') {
   // sendkeys.sendKeys('ls{tab}{tab}')
   sendkeys.sendKeys('ls{enter}')
+  sendkeys.sendKeys('Hello{left}{left}')
 }


### PR DESCRIPTION
Seems like arrow keys does not work in Linux. This PR should fix that.

### Reproduction:

```
const sendkeys = require('sendkeys-js')
sendkeys.sendKeys('Hello{left}{left}')
```

or 

```
const sendkeys = require('sendkeys-js')
setInterval(() => sendkeys.send('left'), 1000)
```

Fix #1